### PR TITLE
COMP: ITKv3 and VTK5 issues

### DIFF
--- a/SkullStripper.cxx
+++ b/SkullStripper.cxx
@@ -150,7 +150,7 @@ LabelImageType::Pointer BinaryClosingFilter3D ( LabelImageType::Pointer & img , 
 void PolyDataToLabelMap( vtkPolyData* polyData, LabelImageType::Pointer label)
 {
   vtkSmartPointer<vtkPolyDataPointSampler> sampler = vtkSmartPointer<vtkPolyDataPointSampler>::New();
-  sampler->SetInput( polyData );
+  sampler->SetInputData( polyData );
   sampler->SetDistance( 0.75 );
   sampler->GenerateEdgePointsOn();
   sampler->GenerateInteriorPointsOn();
@@ -1691,7 +1691,7 @@ int main( int argc, char *argv[] )
 
   vtkSmartPointer<vtkXMLPolyDataWriter> wPoly = vtkSmartPointer<vtkXMLPolyDataWriter>::New();
   wPoly->SetFileName(brainSurface.c_str());
-  wPoly->SetInput(polyData);    
+  wPoly->SetInputData(polyData);    
   wPoly->Update();
 
   allPoints = polyData->GetPoints();

--- a/itkFuzzyClassificationImageFilter.h
+++ b/itkFuzzyClassificationImageFilter.h
@@ -78,7 +78,7 @@ public:
   void SetNumberOfClasses( int n )
   {
     this->m_NumberOfClasses = n;
-    this->SetNumberOfOutputs( n );
+    this->SetNumberOfIndexedOutputs( n );
     return;
   }
 

--- a/itkFuzzyClassificationImageFilter.txx
+++ b/itkFuzzyClassificationImageFilter.txx
@@ -54,7 +54,7 @@ FuzzyClassificationImageFilter<TInputImage, TOutputImage>
   m_ImageMask = NULL;
 
   typename TOutputImage::Pointer output = TOutputImage::New();
-  this->ProcessObject::SetNumberOfOutputs( m_NumberOfClasses );
+  this->ProcessObject::SetNumberOfIndexedOutputs( m_NumberOfClasses );
   this->ProcessObject::SetNthOutput(1, output.GetPointer());
 
   this->m_ClassCentroid.resize( m_NumberOfClasses );
@@ -230,7 +230,7 @@ FuzzyClassificationImageFilter<TInputImage, TOutputImage>
 
   std::sort(classCentroidWithIndex.begin(), classCentroidWithIndex.end(),  func4sortpairs );
 
-  this->SetNumberOfOutputs( this->m_NumberOfClasses );
+  this->SetNumberOfIndexedOutputs( this->m_NumberOfClasses );
 
   for (int k = 0; k < this->m_NumberOfClasses; k++)
   {


### PR DESCRIPTION
ITKv3 compatibility will be turned off in the next Slicer
release. Also, the extension was not working with VTK6.

This patch resolves the issues caused by changes in the api's.